### PR TITLE
Refactor English date candidate pipeline

### DIFF
--- a/lexnlp/extract/en/date_validation.py
+++ b/lexnlp/extract/en/date_validation.py
@@ -1,0 +1,80 @@
+"""Validation helpers for English date extraction."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+
+
+def _ordinal_to_cardinal(value: str) -> Optional[int]:
+    digits = ''.join(char for char in value if char.isdigit())
+    return int(digits) if digits else None
+
+
+def _collect_candidate_values(date_props: Dict[str, Any],
+                              month_lookup: Mapping[str, int]) -> Dict[str, Iterable[int]]:
+    digits: Sequence[str] = date_props.get('digits', [])
+    months: Sequence[str] = date_props.get('months', [])
+    modifiers: Sequence[str] = date_props.get('digits_modifier', [])
+
+    digit_values = [int(d) for d in digits if d.isdigit()]
+    month_values = [month_lookup.get(month.lower()) for month in months if month_lookup.get(month.lower())]
+    modifier_values = [value for value in (_ordinal_to_cardinal(mod) for mod in modifiers) if value]
+
+    return {
+        'digits': digit_values,
+        'months': month_values,
+        'modifiers': modifier_values,
+    }
+
+
+def check_date_parts_are_in_date(
+        date: datetime.datetime,
+        date_props: Dict[str, Any],
+        month_lookup: Optional[Mapping[str, int]] = None) -> bool:
+    """Ensure parsed ``date`` still references the tokens found in ``date_props``."""
+    month_lookup = month_lookup or {}
+
+    units_of_time = ('year', 'month', 'day', 'hour', 'minute')
+    date_values = {unit: getattr(date, unit, None) for unit in units_of_time if hasattr(date, unit)}
+
+    candidate_values = _collect_candidate_values(date_props, month_lookup)
+
+    if candidate_values['months']:
+        month = date_values.get('month')
+        if month and month not in candidate_values['months']:
+            return False
+
+    combined = [
+        *candidate_values['digits'],
+        *candidate_values['months'],
+        *candidate_values['modifiers']
+    ]
+    difference = set(combined).difference(value for value in date_values.values() if value is not None)
+
+    removeable = []
+    reassembled_date: Dict[str, int] = {}
+
+    for unit, value in date_values.items():
+        if value is None:
+            continue
+        if unit == 'year':
+            short_year = (value - 100 * (value // 100)) if value > 1000 else value
+            if short_year in combined:
+                reassembled_date[unit] = value
+                removeable.append(short_year)
+                continue
+        if value in combined:
+            reassembled_date[unit] = value
+            removeable.append(value)
+
+    diff_digits = [digit for digit in difference if digit not in removeable]
+    diff_units = set(date_values.keys()) - set(reassembled_date.keys())
+
+    if any(unit for unit in diff_units if unit in units_of_time[:3]):
+        if diff_digits:
+            return False
+    return True
+
+
+__all__ = ['check_date_parts_are_in_date']

--- a/lexnlp/extract/en/tests/test_dates_pipeline.py
+++ b/lexnlp/extract/en/tests/test_dates_pipeline.py
@@ -1,0 +1,69 @@
+import datetime
+
+from lexnlp.extract.all_locales.languages import Locale
+from lexnlp.extract.en import dates
+from lexnlp.extract.en.date_validation import check_date_parts_are_in_date
+
+
+def test_reject_impossible_formats_multiple_months():
+    finder = dates.DateFinder(base_date=datetime.datetime(2020, 1, 1))
+    locale = Locale('en-US')
+    candidate = dates.CandidateDate(
+        raw_text='Jan Feb',
+        span=(0, 7),
+        props={
+            'months': ['Jan', 'Feb'],
+            'digits_modifier': [],
+            'digits': [],
+            'days': [],
+            'delimiters': [],
+            'extra_tokens': []
+        },
+        index=0,
+        date_finder=finder,
+        locale=locale
+    )
+
+    reason = dates._reject_impossible_formats(candidate)
+    assert reason == 'multiple_month_tokens'
+
+
+def test_pipeline_accepts_valid_date():
+    text = 'Dated as of June 1, 2017.'
+    locale = Locale('en-US')
+    outcomes = list(dates._candidate_outcomes(text, False, datetime.datetime(2017, 1, 1), locale))
+
+    accepted = [outcome for outcome in outcomes if outcome.accepted]
+    assert accepted
+    assert accepted[0].date == datetime.date(2017, 6, 1)
+
+
+def test_pipeline_rejects_decimal_without_month():
+    text = 'Section on 6.25'
+    locale = Locale('en-US')
+    outcomes = list(dates._candidate_outcomes(text, False, datetime.datetime(2017, 1, 1), locale))
+
+    rejections = [outcome for outcome in outcomes if not outcome.accepted]
+    assert rejections
+    assert rejections[0].reason == 'decimal_without_month'
+
+
+def test_check_date_parts_are_in_date_month_validation():
+    base_date = datetime.datetime(2017, 6, 1)
+    props = {
+        'digits': ['1', '2017'],
+        'digits_modifier': [],
+        'months': ['June'],
+        'days': [],
+        'delimiters': []
+    }
+    assert check_date_parts_are_in_date(base_date, props, month_lookup=dates.MONTH_BY_NAME)
+
+    mismatched_props = {
+        'digits': ['1', '2017'],
+        'digits_modifier': [],
+        'months': ['July'],
+        'days': [],
+        'delimiters': []
+    }
+    assert not check_date_parts_are_in_date(base_date, mismatched_props, month_lookup=dates.MONTH_BY_NAME)


### PR DESCRIPTION
## Summary
- refactor `lexnlp.extract.en.dates` to introduce structured candidate evaluation helpers and remove ad-hoc bookkeeping
- move the `check_date_parts_are_in_date` logic into a dedicated validation module and reuse it from the annotation pipeline
- add unit tests that exercise the new helpers and confirm the pipeline accepts and rejects the expected examples

## Testing
- pytest lexnlp/extract/en/tests/test_dates_pipeline.py lexnlp/extract/en/tests/test_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68deb61ddab08328920d5396845fde2c